### PR TITLE
Bugfixed when arguments are used double slashes + testCase

### DIFF
--- a/lib/comment-parser.js
+++ b/lib/comment-parser.js
@@ -45,7 +45,7 @@ const parseComments = (input) => {
         insideMultilineComment = true
         i += 1
         continue
-      } else if (input[i + 1] === '/') {
+      } else if (input[i + 1] === '/' && input[i - 1] !== ':') {  // String "https://" or "// Comment"
         flush()
         currentNode.type = 'comment'
         insideSinglelineComment = true

--- a/lib/comment-parser.test.js
+++ b/lib/comment-parser.test.js
@@ -69,5 +69,16 @@ tap.test('jsdoctest/comment-parser', (t) => {
   )
   */
 
+  t.same(
+    commentParser.parseExamples(commentParser.parseComments(
+      'get("http://smappi.org")\n' +
+      '// ignored\n' +
+      'get("https://smappi.org")\n' +
+      '// => 20'
+    )),
+    [ { displayTestCase: 'get("https://smappi.org")', testCase: 'get("https://smappi.org")', expectedResult: '20' } ],
+    '.parseComments(parseComments) extracts examples with double slashes as arguments, example func("https://smappi.org")'
+  )
+
   t.end()
 })


### PR DESCRIPTION
Bugfixed when arguments are used double slashes.

```
@example
func("https://smappi.org")
// => "https://smappi.org"
```